### PR TITLE
Update RDCOMClient

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+src/*.o
+src/*.so
+src/*.dll

--- a/RDCOMClient.Rproj
+++ b/RDCOMClient.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/src/converters.cpp
+++ b/src/converters.cpp
@@ -145,7 +145,8 @@ getArray(SAFEARRAY *arr, int dimNo, int numDims, long *indices)
       case LGLSXP:
       case REALSXP:
       case STRSXP:
-	ans = UnList(ans);
+	// ans = UnList(ans);
+	ans = ans;
 	break;
     }
   }

--- a/src/converters.cpp
+++ b/src/converters.cpp
@@ -139,17 +139,7 @@ getArray(SAFEARRAY *arr, int dimNo, int numDims, long *indices)
     }
     SET_VECTOR_ELT(ans, i, el);
   }
-  if(numDims == 1 && rtype != -1) {
-    switch(rtype) {
-      case INTSXP:
-      case LGLSXP:
-      case REALSXP:
-      case STRSXP:
-	// ans = UnList(ans);
-	ans = ans;
-	break;
-    }
-  }
+
   UNPROTECT(1);
 
   return(ans);


### PR DESCRIPTION
The first (minor) change was to make this an Rstudio package project, which made it easier for me to work with. Secondly, I changed a small section of converters.cpp. The call to UnList() was too heavy. When I returned a nested array like

`{{1, 2}, {3, 4}}`

it was being flattened into

`{1, 2, 3, 4}`

Removing that section resolved the issue, but of course, this no longer converts anything to R vectors automatically. I've found that calling unlist() in my R project code as needed is just fine. The other option would be to improve the logic of the if block. `numDims == 1 && rtype != -1` wasn't quite right.

Finally, I noticed that after rebuilding the package in 3.6.1, I was no longer getting the errors referenced in omegahat/RDCOMClient#19.