### PR TITLE
The following changes makes RDCOMClient work again with recent versions of R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: RDCOMClient
-Version: 0.94-0
+Version: 0.95-0
 Title: R-DCOM client
 Author:  Duncan Temple Lang <duncan@r-project.org>
 Maintainer: Duncan Temple Lang <duncan@r-project.org>

--- a/man/writeErrors.Rd
+++ b/man/writeErrors.Rd
@@ -3,8 +3,8 @@
 \title{Query or set whether DCOM errors are written to a file}
 \description{
  This function allows one to query or set the flag that controls
-whether DCOM errors are appended to a file (c:/DCOM.err) when
-they are encountered.  
+whether DCOM errors are appended to a file (\code{\%TMP\%/RDCOM.err}) when
+they are encountered. 
 }
 \usage{
 writeErrors(val = logical())

--- a/src/COMError.cpp
+++ b/src/COMError.cpp
@@ -23,16 +23,31 @@ RDCOM_getWriteError(SEXP value)
     return(ScalarLogical(RDCOM_WriteErrors));
 }
 
+
+
 FILE *
 getErrorFILE()
 {
   static FILE *f = NULL;
-  if(!f) {
-    f = fopen("C:\\RDCOM.err", "a");
-    if(!f) {
-      f = fopen("C:\\RDCOM_server.err", "a");
+
+  if (f)
+    return f;
+
+  TCHAR path[MAX_PATH];
+  DWORD result;
+
+  result = GetTempPath(MAX_PATH, path);
+
+  if (result > MAX_PATH-10 || result == 0) {
+    f = stderr;
+  } else {
+    lstrcat(path, _T("RDCOM.err"));
+    f = fopen(path, "a");
+    if (!f) {
+      f = stderr;
     }
   }
+
   return(f);
 }
 

--- a/src/COMError.cpp
+++ b/src/COMError.cpp
@@ -5,7 +5,8 @@
 
 #include <tchar.h>
 
-extern "C" int RDCOM_WriteErrors = 1;
+extern "C" int RDCOM_WriteErrors;
+int RDCOM_WriteErrors = 1;
 
 extern "C"
 SEXP
@@ -375,8 +376,9 @@ SEXP R_createCOMErrorCodes();
 	#undef MAKE_HRESULT_ENTRY
 
 
-
+#ifndef _countof
 #define _countof(array) (sizeof(array)/sizeof(array[0]))
+#endif
 void GetScodeString(HRESULT hr, LPTSTR buf, int bufSize)
 {
 	// first ask the OS to give it to us..
@@ -400,7 +402,7 @@ void GetScodeString(HRESULT hr, LPTSTR buf, int bufSize)
 		}
 	}
 	// not found - make one up
-	sprintf(buf, ("OLE error 0x%08x"), hr);
+	sprintf(buf, ("OLE error 0x%08lx"), hr);
 }
 
 
@@ -438,7 +440,7 @@ checkErrorInfo(IUnknown *obj, HRESULT status, SEXP *serr)
   HRESULT hr;
   ISupportErrorInfo *info;
 
-  fprintf(stderr, "<checkErrorInfo> %X \n", status);
+  fprintf(stderr, "<checkErrorInfo> %lX \n", status);
 
   if(serr) 
     *serr = NULL;

--- a/src/RCOMObject.cpp
+++ b/src/RCOMObject.cpp
@@ -8,7 +8,7 @@ extern "C" {
 }
 
 bool isCOMError(SEXP obj);
-bool isClass(SEXP obj, char *name);
+bool isClass(SEXP obj, const char *name);
 HRESULT processCOMError(SEXP obj, EXCEPINFO *excep, UINT *argNum);
 static SEXP callQueryInterfaceMethod(SEXP obj, char *guid);
 
@@ -118,10 +118,7 @@ callQueryInterfaceMethod(SEXP obj, char *guid)
 HRESULT __stdcall
 RCOMEnvironmentObject::GetIDsOfNames(REFIID refId, LPOLESTR *name, UINT cNames, LCID local, DISPID *id)
 {
-  SEXP sid;
-  int i, n;
   SEXP names;
-  char str[90];
   HRESULT hr;
 
 #ifdef RDCOM_VERBOSE
@@ -169,7 +166,7 @@ RCOMObject::lookupRName(SEXP names, const char * const str, DISPID *id)
   if(i == n) {
     errorLog("Couldn't find method %s\n", str);
   } else {
-    errorLog("Method id for %s = %d\n", str,  *id);
+    errorLog("Method id for %s = %ld\n", str,  *id);
   }
 #endif
 
@@ -183,7 +180,7 @@ RCOMEnvironmentObject::Invoke(DISPID id, REFIID refId, LCID locale, WORD method,
  SEXP func;
 
 #ifdef RDCOM_VERBOSE
- errorLog("Method id %d, method = %s",  id, method);
+ errorLog("Method id %ld, method = %d",  id, method);
 #endif
  func = VECTOR_ELT(this->obj, id);
 
@@ -294,7 +291,7 @@ SEXP
 asRStringVector(LPOLESTR *name, UINT cNames)
 {
   SEXP tmp;
-  int i;
+  UINT i;
   char str[1000];
   PROTECT(tmp = allocVector(STRSXP, cNames));
   for(i = 0; i < cNames; i++) {
@@ -309,8 +306,9 @@ asRStringVector(LPOLESTR *name, UINT cNames)
 HRESULT __stdcall
 RCOMSObject::GetIDsOfNames(REFIID refId, LPOLESTR *name, UINT cNames, LCID locale, DISPID *id)
 {
-  SEXP e, val, tmp;
-  int errorOccurred, i;
+  SEXP e, val;
+  int errorOccurred;
+  UINT i;
 
   PROTECT(e = allocVector(LANGSXP, 2));
   SETCAR(e, VECTOR_ELT(this->obj, IDS_OF_NAMES));
@@ -353,9 +351,9 @@ HRESULT __stdcall
 RCOMSObject::Invoke(DISPID id, REFIID refId, LCID locale, WORD method, DISPPARAMS *parms, 
 				     VARIANT *var, EXCEPINFO *excep, UINT *argNumErr)
 {
-  int errorOccurred, i;
+  int errorOccurred;
+  UINT i;
   SEXP e, ptr, val, tmp;
-  HRESULT hr;
 
 #if defined(RDCOM_VERBOSE) && RDCOM_VERBOSE
   errorLog("About to call RCOMSObject::Invoke\n");
@@ -416,7 +414,7 @@ RCOMSObject::Invoke(DISPID id, REFIID refId, LCID locale, WORD method, DISPPARAM
     return(status);
   }
   
-  hr = convertToCOM(val, var);
+  convertToCOM(val, var);
   UNPROTECT(2);
 
   return(S_OK);
@@ -442,7 +440,7 @@ isCOMError(SEXP obj)
 }
 
 bool
-isClass(SEXP obj, char *name)
+isClass(SEXP obj, const char *name)
 {
  SEXP klass;
  klass = GET_CLASS(obj);

--- a/src/RCOMObject.h
+++ b/src/RCOMObject.h
@@ -87,7 +87,7 @@ class RCOMObject : public IDispatch
                           if(def != R_NilValue)
                              setObject(def);
                        };
-  ~RCOMObject() {
+  virtual ~RCOMObject() {
                   m_cRef--;
                   if(m_cRef == 0) {
 		    destroy();

--- a/src/connect.cpp
+++ b/src/connect.cpp
@@ -402,7 +402,6 @@ SEXP getArray(SAFEARRAY *arr, int dimNo, int numDims, long *indices);
 HRESULT
 R_getCOMArgs(SEXP args, DISPPARAMS *parms, DISPID *ids, int numNamedArgs, int *namedArgPositions)
 {
- HRESULT hr;
  int numArgs = Rf_length(args), i, ctr;
  if(numArgs == 0)
    return(S_OK);
@@ -441,7 +440,7 @@ R_getCOMArgs(SEXP args, DISPPARAMS *parms, DISPID *ids, int numNamedArgs, int *n
      }
      el = VECTOR_ELT(args, i);
      VariantInit(var);
-     hr = R_convertRObjectToDCOM(el, var);
+     R_convertRObjectToDCOM(el, var);
    }
  } else {
 
@@ -451,7 +450,7 @@ R_getCOMArgs(SEXP args, DISPPARAMS *parms, DISPID *ids, int numNamedArgs, int *n
    for(i = 0, ctr = numArgs-1; i < numArgs; i++, ctr--) {
      SEXP el = VECTOR_ELT(args, i);
      VariantInit(&parms->rgvarg[ctr]);
-     hr = R_convertRObjectToDCOM(el, &(parms->rgvarg[ctr]));
+     R_convertRObjectToDCOM(el, &(parms->rgvarg[ctr]));
    }
  }
 

--- a/src/converters.cpp
+++ b/src/converters.cpp
@@ -362,7 +362,6 @@ SEXP
 R_convertDCOMObjectToR(VARIANT *var)
 {
   SEXP ans = R_NilValue;
-  HRESULT hr;
 
   VARTYPE type = V_VT(var);
 
@@ -438,7 +437,7 @@ R_convertDCOMObjectToR(VARIANT *var)
     case VT_UI2:
     case VT_UI4:
     case VT_UINT:
-      hr = VariantChangeType(var, var, 0, VT_I4);
+      VariantChangeType(var, var, 0, VT_I4);
       ans = R_scalarReal((double) V_I4(var));
       break;
 
@@ -446,14 +445,14 @@ R_convertDCOMObjectToR(VARIANT *var)
     case VT_I2:
     case VT_I4:
     case VT_INT:
-      hr = VariantChangeType(var, var, 0, VT_I4);
+      VariantChangeType(var, var, 0, VT_I4);
       ans = R_scalarInteger(V_I4(var));
       break;
 
     case VT_R4:
     case VT_R8:
     case VT_I8:
-      hr = VariantChangeType(var, var, 0, VT_R8);
+      VariantChangeType(var, var, 0, VT_R8);
       ans = R_scalarReal(V_R8(var));
       break;
 
@@ -461,7 +460,7 @@ R_convertDCOMObjectToR(VARIANT *var)
     case VT_DATE:
     case VT_HRESULT:
     case VT_DECIMAL:
-      hr = VariantChangeType(var, var, 0, VT_R8);
+      VariantChangeType(var, var, 0, VT_R8);
       ans = numberFromVariant(var, type);
       break;
 


### PR DESCRIPTION
Moves C:\RDCOM.err to %TMP%\RDCOM.err with fallback to stderr, this avoids a crash. 
Also: compiles without warnings on r 4.1.1 and rtools 4.1. 
