### PR TITLE
Add support for unicode strings

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,8 @@
 
+??
+
++ Support unicode strings by converting to/from UTF8-encoded strings in R.
+
 0.96-1
 
 + Removed the check in [[<- to see if the property is read-only. Have to handle case where there are two property elements in the type library with the same name (e.g., Visible) with a PROPERTYGET and PROPERTYPUT.

--- a/src/COMError.cpp
+++ b/src/COMError.cpp
@@ -482,13 +482,13 @@ checkErrorInfo(IUnknown *obj, HRESULT status, SEXP *serr)
 
    PROTECT(tmp = NEW_CHARACTER(1));
    errorInfo->GetSource(&ostr);
-   SET_STRING_ELT(tmp, 0, COPY_TO_USER_STRING(FromBstr(ostr)));
+   SET_STRING_ELT(tmp, 0, mkCharCE(FromBstr(ostr), CE_UTF8));
    SET_SLOT(ans, Rf_install("source"), tmp);
    UNPROTECT(1);
 
    PROTECT(tmp = NEW_CHARACTER(1));
    errorInfo->GetDescription(&ostr);
-   SET_STRING_ELT(tmp, 0, COPY_TO_USER_STRING(str = FromBstr(ostr)));
+   SET_STRING_ELT(tmp, 0, mkCharCE(str = FromBstr(ostr), CE_UTF8));
    SET_SLOT(ans, Rf_install("description"), tmp);
    UNPROTECT(1);
 

--- a/src/RUtils.c
+++ b/src/RUtils.c
@@ -223,7 +223,7 @@ R_scalarString(const char * const v)
   SEXP ans = allocVector(STRSXP, 1);
   PROTECT(ans);
   if(v)
-    SET_STRING_ELT(ans, 0, mkChar(v));
+    SET_STRING_ELT(ans, 0, mkCharCE(v, CE_UTF8));
   UNPROTECT(1);
   return(ans);
 }
@@ -282,7 +282,7 @@ getRNilValue(void)
 const char *
 getRString(SEXP str, int which)
 {
- return(CHAR(STRING_ELT(str, which)));
+ return(translateCharUTF8(STRING_ELT(str, which)));
 }
 
 SEXP getRNames(SEXP obj)

--- a/src/converters.cpp
+++ b/src/converters.cpp
@@ -26,9 +26,9 @@ AsBstr(const char *str)
     return(NULL);
 
   int size = strlen(str);
-  int wideSize = 2 * size;
+  int wideSize = MultiByteToWideChar(CP_UTF8, 0, str, -1, NULL, 0);
   LPOLESTR wstr = (LPWSTR) S_alloc(wideSize, sizeof(OLECHAR)); 
-  if(MultiByteToWideChar(CP_ACP, 0, str, size, wstr, wideSize) == 0 && str[0]) {
+  if(MultiByteToWideChar(CP_UTF8, 0, str, size, wstr, wideSize) == 0 && str[0]) {
     PROBLEM "Can't create BSTR for '%s'", str
     ERROR;
   }
@@ -47,15 +47,14 @@ FromBstr(BSTR str)
   if(!str)
     return(NULL);
 
-  len = wcslen(str);
+  len = WideCharToMultiByte(CP_UTF8, 0, str, -1, NULL, 0, NULL, NULL);
 
   if(len < 1)
     len = 0;
 
-  ptr = (char *) S_alloc(len+1, sizeof(char));
-  ptr[len] = '\0';
+  ptr = (char *) S_alloc(len, sizeof(char));
   if(len > 0) {
-    DWORD ok = WideCharToMultiByte(CP_ACP, 0, str, len, ptr, len, NULL, NULL);
+    DWORD ok = WideCharToMultiByte(CP_UTF8, 0, str, -1, ptr, len, NULL, NULL);
     if(ok == 0) 
       ptr = NULL;
   }
@@ -841,7 +840,7 @@ R_create2DArray(SEXP obj)
           el = &integer;
 	  break;
         case STRSXP:
-	  bstr = AsBstr(CHAR(STRING_ELT(obj, ctr)));
+	  bstr = AsBstr(translateCharUTF8(STRING_ELT(obj, ctr)));
           el = (void*) bstr;
 	  break;
         default:


### PR DESCRIPTION
I was trying to read a cell value in Excel that contained unicode data. I found that strings with non-ascii values seem to just return a blank string:

> excel$ActiveWorkbook()$ActiveSheet()$Range('A1')$Value()
[1] ""
> Encoding(s)
[1] "unknown"

This pull request changes FromBstr/AsBstr to use UTF8, so that this now works as expected:

> (s<-excel$ActiveWorkbook()$ActiveSheet()$Range('A1')$Value())
[1] "1234³"
> Encoding(s)
[1] "UTF-8"

An alternative workaround that might be applicable for others is to use win32com.client via reticulate, but I didn't want to require a python installation:

> library(reticulate)
> excel2 = import('win32com.client')$Dispatch('excel.application')
> excel2$ActiveWorkbook$ActiveSheet$Range('A1')$Value
[1] "1234³"

I've also verified that writing unicode values works now with these changes also.

Note that there are still a bunch of places where we use non-encoding aware conversions, primarily around dispatch (method/property/type names etc), which I presume is fine. The focus here was on errors and values.

Let me know if there's some changes you'd want to see for this to be accepted. Thanks!